### PR TITLE
Limit terminal viewport to classic 80×24 layout

### DIFF
--- a/Vault-Tec Terminal.html
+++ b/Vault-Tec Terminal.html
@@ -81,17 +81,21 @@
 
     /* UI */
     #ui{position:absolute; inset:0; display:none}
-    .menu{overflow:auto; height:100%; display:flex; flex-direction:column; justify-content:center}
-    .panel{display:none; overflow:auto; height:100%}
+    .menu{overflow:auto; height:100%; display:flex; flex-direction:column; position:relative}
+    .menu .options{margin-top:auto}
+    .panel{display:none; overflow:auto; height:100%; position:relative}
     .back{display:block; margin-top:10px}
 
     .menu h3{margin:0 0 12px 0; font-size:1.3em; text-align:center}
+    .ascii{white-space:pre; font-variant-ligatures:none; text-align:center;}
     button{font:inherit; color:inherit; background:transparent; border:none; padding:0; cursor:pointer}
     button:hover{color:var(--accent)}
     .menu button{display:block; width:100%; text-align:left; margin:4px 0; font-size:1.2em}
     .menu button::before{content:"> "; color:var(--accent); opacity:0}
     .menu button:hover::before,.menu button.active::before{opacity:1}
     .menu button:hover,.menu button.active{color:var(--accent)}
+
+    .typing{position:absolute; inset:0; white-space:pre-wrap; pointer-events:none}
 
     .listing{white-space:pre; font-variant-ligatures:none; margin:6px 0}
     .status-ok{color:#7fffb0}.status-warn{color:#ffe27f}.status-bad{color:#ff9f9f}
@@ -173,15 +177,26 @@
         <!-- MAIN UI -->
           <section id="ui">
             <div id="mainMenu" class="menu">
-              <h3>MAIN MENU</h3>
-              <button class="active" data-target="panel-status">Vault Status</button>
-              <button data-target="panel-controls">Systems Control</button>
-              <button data-target="panel-security">Security Logs</button>
-              <button data-target="panel-directives">Overseer Directives</button>
-              <button data-target="panel-lore">Repository: Lore</button>
-              <button data-target="panel-diagnostics">Diagnostics</button>
-              <button data-target="panel-settings">Terminal Settings</button>
-              <div class="dim" style="margin-top:10px">[↑/↓] Navigate  [Enter] Select</div>
+              <pre id="vaultAscii" class="ascii">
+   ____      _   _ _   _ _____      _______          
+  |  _ \    | | | | \ | |_   _|    |__   __|         
+  | |_) |_ _| | | |  \| | | | ___     | | ___  _ __  
+  |  _ <| '__| | | | . ` | | |/ _ \    | |/ _ \| '_ \ 
+  | |_) | |  | |_| | |\  |_| | (_) |   | | (_) | | | |
+  |____/|_|   \___/|_| \_|_____|\___|   |_|\___/|_| |_|
+                      VAULT 100
+              </pre>
+              <div class="options">
+                <h3>MAIN MENU</h3>
+                <button class="active" data-target="panel-status">Vault Status</button>
+                <button data-target="panel-controls">Systems Control</button>
+                <button data-target="panel-security">Security Logs</button>
+                <button data-target="panel-directives">Overseer Directives</button>
+                <button data-target="panel-lore">Repository: Lore</button>
+                <button data-target="panel-diagnostics">Diagnostics</button>
+                <button data-target="panel-settings">Terminal Settings</button>
+                <div class="dim" style="margin-top:10px">[↑/↓] Navigate  [Enter] Select</div>
+              </div>
             </div>
 
             <section id="panel-status" class="panel">
@@ -488,33 +503,59 @@
     addEventListener('keyup', (e)=>{ if(e.code==='Space' && document.activeElement!==cmdInput){ accel=false; } });
 
       // ===== Menu / Nav =====
+      function typeText(el, text, done){
+        let i=0; const speed=14;
+        function step(){
+          if(i<text.length){
+            const ch=text[i];
+            el.textContent += ch;
+            if(ch!==' '&& ch!=='\n') Beeper.tick();
+            i++; setTimeout(step, speed);
+          } else { done && done(); }
+        }
+        step();
+      }
+
+      function typeScreen(container, cb){
+        const text = container.dataset.text || container.innerText;
+        container.dataset.text = text;
+        const overlay=document.createElement('pre');
+        overlay.className='typing';
+        const kids=[...container.children];
+        kids.forEach(k=> k.style.display='none');
+        container.appendChild(overlay);
+        typeText(overlay, text, ()=>{
+          overlay.remove();
+          kids.forEach(k=> k.style.display='');
+          cb && cb();
+        });
+      }
+
       const menu = document.getElementById('mainMenu');
       const menuBtns = [...menu.querySelectorAll('button[data-target]')];
       const panels = [...document.querySelectorAll('#ui .panel')];
-      const backBtns = [...document.querySelectorAll('.back')];
       let idx = 0;
       function showMenu(){
-        menu.style.display='block';
         panels.forEach(p=> p.style.display='none');
-        idx = 0;
-        menuBtns.forEach((b,i)=> b.classList.toggle('active', i===idx));
-        menuBtns[idx].focus();
-        Beeper.beep(760, .03);
+        menu.style.display='block';
+        idx=0;
+        typeScreen(menu, ()=>{ highlight(); Beeper.beep(760,.03); });
       }
       function showPanel(id){
         menu.style.display='none';
         panels.forEach(p=> p.style.display = (p.id===id)?'block':'none');
-        Beeper.beep(760, .03);
+        const panel = document.getElementById(id);
+        typeScreen(panel, ()=>Beeper.beep(760,.03));
       }
       menuBtns.forEach((b,i)=> b.addEventListener('click', ()=>{ idx=i; showPanel(b.dataset.target); }));
-      backBtns.forEach(btn=> btn.addEventListener('click', showMenu));
+      ui.addEventListener('click', e=>{ if(e.target.classList.contains('back')) showMenu(); });
       document.querySelectorAll('button').forEach(btn=> btn.addEventListener('mouseenter', ()=>Beeper.beep(520,.02)));
-      function highlight(){ menuBtns.forEach((b,i)=> b.classList.toggle('active', i===idx)); menuBtns[idx].focus(); Beeper.beep(520,.02); }
+      function highlight(){ menuBtns.forEach((b,i)=> b.classList.toggle('active', i===idx)); menuBtns[idx].focus(); }
       addEventListener('keydown', (e)=>{
         if(document.activeElement===cmdInput || ui.style.display==='none') return;
         if(menu.style.display!=='none'){
-          if(e.key==='ArrowDown'){ idx = (idx+1)%menuBtns.length; highlight(); }
-          else if(e.key==='ArrowUp'){ idx = (idx-1+menuBtns.length)%menuBtns.length; highlight(); }
+          if(e.key==='ArrowDown'){ idx = (idx+1)%menuBtns.length; highlight(); Beeper.beep(520,.02); }
+          else if(e.key==='ArrowUp'){ idx = (idx-1+menuBtns.length)%menuBtns.length; highlight(); Beeper.beep(520,.02); }
           else if(e.key==='Enter'){ menuBtns[idx].click(); }
         } else {
           if(e.key.toLowerCase()==='m'){ showMenu(); }

--- a/Vault-Tec Terminal.html
+++ b/Vault-Tec Terminal.html
@@ -12,7 +12,7 @@
       --accent:#caffca;
       --amber:#ffd18a;
       --amber-dim:#a2763a;
-      --pad:18px;
+      --pad:24px;
     }
     *{box-sizing:border-box}
     html,body{height:100%}
@@ -20,18 +20,18 @@
       margin:0;background:var(--bg);color:var(--fg);
       font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
       letter-spacing:.25px; line-height:1.15; overflow:hidden;
-      font-size: clamp(12px, 1.7vh, 18px); /* scale up on big screens */
+      font-size: clamp(16px, 2.4vh, 24px); /* larger type for WANG style */
     }
 
     /* TERMINAL SHELL */
     .shell{position:relative;height:100%;display:grid;place-items:center}
     .bezel{
-      /* fixed viewport similar to Fallout terminals (approx 80x24 chars) */
+      /* expanded viewport reminiscent of WANG terminals */
       position:relative;
-      width: calc(80ch + 2*var(--pad));
-      height: calc(24 * 1.15em + 2*var(--pad));
-      border: 2px solid currentColor; padding: var(--pad); overflow:hidden;
-      border-radius: 12px; box-shadow: inset 0 0 80px rgba(120,255,140,.08), 0 0 30px rgba(120,255,140,.1);
+      width: calc(100ch + 2*var(--pad));
+      height: calc(30 * 1.15em + 2*var(--pad));
+      border: 4px solid currentColor; padding: var(--pad); overflow:hidden;
+      border-radius: 6px; box-shadow: inset 0 0 80px rgba(120,255,140,.08), 0 0 30px rgba(120,255,140,.1);
     }
     .bezel::before{ /* scanlines */
       content:""; position:absolute; inset:0; pointer-events:none;
@@ -61,10 +61,10 @@
 
     /* TERMINAL TEXT AREA */
     .term{
-      /* constrain text area to classic 80x24 characters */
+      /* expanded text area roughly 100x30 characters */
       position:relative;
-      width:80ch;
-      height:calc(24 * 1.15em);
+      width:100ch;
+      height:calc(30 * 1.15em);
       overflow:hidden;
     }
     .row{white-space:pre; font-variant-ligatures:none}
@@ -81,14 +81,14 @@
 
     /* UI */
     #ui{position:absolute; inset:0; display:none}
-    .menu{overflow:auto; height:100%}
+    .menu{overflow:auto; height:100%; display:flex; flex-direction:column; justify-content:center}
     .panel{display:none; overflow:auto; height:100%}
     .back{display:block; margin-top:10px}
 
-    .menu h3{margin:0 0 8px 0; font-size:14px}
+    .menu h3{margin:0 0 12px 0; font-size:1.3em; text-align:center}
     button{font:inherit; color:inherit; background:transparent; border:none; padding:0; cursor:pointer}
     button:hover{color:var(--accent)}
-    .menu button{display:block; width:100%; text-align:left; margin:2px 0}
+    .menu button{display:block; width:100%; text-align:left; margin:4px 0; font-size:1.2em}
     .menu button::before{content:"> "; color:var(--accent); opacity:0}
     .menu button:hover::before,.menu button.active::before{opacity:1}
     .menu button:hover,.menu button.active{color:var(--accent)}

--- a/Vault-Tec Terminal.html
+++ b/Vault-Tec Terminal.html
@@ -80,9 +80,10 @@
     #bootScroll{height:100%; overflow:auto}
 
     /* UI */
-    #ui{position:absolute; inset:0; display:none; grid-template-columns: 280px 1fr; gap:14px}
-    #sidebar{border-right:1px solid currentColor; padding-right:10px; overflow:auto}
-    #content{overflow:auto}
+    #ui{position:absolute; inset:0; display:none}
+    .menu{overflow:auto; height:100%}
+    .panel{display:none; overflow:auto; height:100%}
+    .back{display:block; margin-top:10px}
 
     .menu h3{margin:0 0 8px 0; font-size:14px}
     button{font:inherit; color:inherit; background:transparent; border:none; padding:0; cursor:pointer}
@@ -146,7 +147,6 @@
     }
     #bootBtn.hidden{display:none}
 
-    @media (max-width: 900px){ #ui{grid-template-columns:1fr} #sidebar{border-right:none; border-bottom:1px solid currentColor; margin-bottom:10px; padding-bottom:10px} }
   </style>
 </head>
 <body>
@@ -171,9 +171,8 @@
         </section>
 
         <!-- MAIN UI -->
-        <section id="ui">
-          <aside id="sidebar">
-            <div class="menu">
+          <section id="ui">
+            <div id="mainMenu" class="menu">
               <h3>MAIN MENU</h3>
               <button class="active" data-target="panel-status">Vault Status</button>
               <button data-target="panel-controls">Systems Control</button>
@@ -182,24 +181,24 @@
               <button data-target="panel-lore">Repository: Lore</button>
               <button data-target="panel-diagnostics">Diagnostics</button>
               <button data-target="panel-settings">Terminal Settings</button>
+              <div class="dim" style="margin-top:10px">[↑/↓] Navigate  [Enter] Select</div>
             </div>
-            <div class="dim" style="margin-top:10px">[↑/↓] Navigate  [Enter] Select  [M] Menu</div>
-          </aside>
-          <main id="content">
-            <section id="panel-status" class="panel" style="display:block">
+
+            <section id="panel-status" class="panel">
               <h2 class="glow">VAULT STATUS</h2>
               <pre class="listing">
-Subsystem           State       Details
-Power Grid          <span class="status-ok">ONLINE</span>      Fusion core output nominal (83%).
-Water Purification  <span class="status-warn">SUBOPTIMAL</span> Filter bed fouling at 21%. Backwash recommended.
-Atmospheric         <span class="status-ok">GREEN</span>       CO2 scrubbers cycling; O2 at 20.8%.
-Food Hydroponics    <span class="status-warn">LOW</span>        Nutrient A shortfall. Substitute algae slurry authorized.
-Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted by Directive 73-B.
+ Subsystem           State       Details
+ Power Grid          <span class="status-ok">ONLINE</span>      Fusion core output nominal (83%).
+ Water Purification  <span class="status-warn">SUBOPTIMAL</span> Filter bed fouling at 21%. Backwash recommended.
+ Atmospheric         <span class="status-ok">GREEN</span>       CO2 scrubbers cycling; O2 at 20.8%.
+ Food Hydroponics    <span class="status-warn">LOW</span>        Nutrient A shortfall. Substitute algae slurry authorized.
+ Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted by Directive 73-B.
               </pre>
               <p class="dim">Tip: From Systems Control, reroute noncritical lighting to Purification to clear backlog faster.</p>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-controls" class="panel" style="display:none">
+            <section id="panel-controls" class="panel">
               <h2 class="glow">SYSTEMS CONTROL</h2>
               <div class="frame" style="margin-bottom:10px">
                 <strong>Power Routing</strong>
@@ -219,9 +218,10 @@ Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted
                   <div id="doorMsg" class="dim" style="margin-top:6px">Status: LOCKED by Overseer policy.</div>
                 </div>
               </div>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-security" class="panel" style="display:none">
+            <section id="panel-security" class="panel">
               <h2 class="glow">SECURITY LOGS</h2>
               <ul>
                 <li>[021.10.23 03:14] Patrol shift β reports scratching from Service Tunnel C. Rodents? (Ticket #C-119)</li>
@@ -231,9 +231,10 @@ Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted
                 <li>[021.10.24 02:26] Camera 7 flicker coincident with seismic microburst. Structural integrity uncompromised.</li>
               </ul>
               <p class="dim">Note: Export detailed logs with command LOG/EXPORT (not available in demo).</p>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-directives" class="panel" style="display:none">
+            <section id="panel-directives" class="panel">
               <h2 class="glow">OVERSEER DIRECTIVES</h2>
               <ol>
                 <li>Maintain Door Lock Protocol 73-B until external radiation index &lt; 5 rads/hr sustained 30 days.</li>
@@ -242,9 +243,10 @@ Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted
                 <li>Prohibit unscheduled excursions to Prospector's Bluff observation deck. Reports of auditory phenomena pending review.</li>
               </ol>
               <p class="dim">Signed, Overseer REYES • Auth Sig: OVR-73B-F1C</p>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-lore" class="panel" style="display:none">
+            <section id="panel-lore" class="panel">
               <h2 class="glow">REPOSITORY: LORE</h2>
               <details open>
                 <summary><strong>VT-88c Terminal Lineage</strong></summary>
@@ -262,28 +264,29 @@ Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted
                 <summary><strong>Food Substitute: Algae Slurry A-17</strong></summary>
                 <p>High-protein emergency ration. Side effects include vivid dreams and a metallic aftertaste. Overseers recommend pepper or dried citrus peel.</p>
               </details>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-diagnostics" class="panel" style="display:none">
+            <section id="panel-diagnostics" class="panel">
               <h2 class="glow">DIAGNOSTICS</h2>
               <div class="frame" style="margin-bottom:10px">
                 <strong>Device Map</strong>
                 <pre class="listing">
-Addr     Device               Status
-0x0010   Water Pump A         <span class="status-ok">OK</span>
-0x0011   CO2 Scrubber B       <span class="status-ok">OK</span>
-0x0200   Hydroponics Feeder   <span class="status-warn">LOW</span>
-0x0300   Door Lock Relay      <span class="status-bad">LOCKED</span>
+ Addr     Device               Status
+ 0x0010   Water Pump A         <span class="status-ok">OK</span>
+ 0x0011   CO2 Scrubber B       <span class="status-ok">OK</span>
+ 0x0200   Hydroponics Feeder   <span class="status-warn">LOW</span>
+ 0x0300   Door Lock Relay      <span class="status-bad">LOCKED</span>
                 </pre>
               </div>
               <div class="frame" style="margin-bottom:10px">
                 <strong>Memory Map</strong>
                 <pre class="listing">
-Range         Region       Notes
-0x0000-0x1FFF Kernel       FO/1.2
-0x2000-0x3FFF Drivers      IO, VDU, KBD
-0x4000-0x7FFF User Space   Terminal UI
-0x8000-0x8FFF VRAM         Monochrome buffer
+ Range         Region       Notes
+ 0x0000-0x1FFF Kernel       FO/1.2
+ 0x2000-0x3FFF Drivers      IO, VDU, KBD
+ 0x4000-0x7FFF User Space   Terminal UI
+ 0x8000-0x8FFF VRAM         Monochrome buffer
                 </pre>
               </div>
               <div class="frame">
@@ -293,9 +296,10 @@ Range         Region       Notes
                 <button id="btnAnomaly" style="margin-left:6px">[INJECT ANOMALY]</button>
                 <div id="diagHint" class="dim" style="margin-top:6px">Press <b>Space</b> to accelerate, <b>Enter</b> to dismiss when finished.</div>
               </div>
+              <button class="back">[RETURN]</button>
             </section>
 
-            <section id="panel-settings" class="panel" style="display:none">
+            <section id="panel-settings" class="panel">
               <h2 class="glow">TERMINAL SETTINGS</h2>
               <div class="frame">
                 <label><input type="checkbox" id="amberToggle"/> Amber monochrome</label><br/>
@@ -303,9 +307,9 @@ Range         Region       Notes
                 <label><input type="checkbox" id="sweepToggle" checked/> Vertical sweep highlight</label>
               </div>
               <p class="dim">Preferences persist for this session only.</p>
+              <button class="back">[RETURN]</button>
             </section>
-          </main>
-        </section>
+          </section>
 
         <div id="cmdline"><span class="prompt">&gt;</span><input id="cmdInput" autocomplete="off" /></div>
 
@@ -459,17 +463,18 @@ Range         Region       Notes
       }
     }
 
-    function finishBoot(){
-      bootDone = true;
-      bootBtn.style.display='none';
-      Beeper.beep(600, .08);
-      setTimeout(()=>{
-        boot.style.display='none';
-        ui.style.display='grid';
-        cmdline.style.display='flex';
-        cmdInput.focus();
-      }, 420);
-    }
+      function finishBoot(){
+        bootDone = true;
+        bootBtn.style.display='none';
+        Beeper.beep(600, .08);
+        setTimeout(()=>{
+          boot.style.display='none';
+          ui.style.display='block';
+          cmdline.style.display='flex';
+          showMenu();
+          cmdInput.focus();
+        }, 420);
+      }
 
     bootBtn.addEventListener('click', ()=>{
       bootBtn.style.display='none';
@@ -482,20 +487,39 @@ Range         Region       Notes
     addEventListener('keydown', (e)=>{ if(e.code==='Space' && document.activeElement!==cmdInput){ accel=true; } if(e.key==='Enter' && !bootDone){ finishBoot(); } });
     addEventListener('keyup', (e)=>{ if(e.code==='Space' && document.activeElement!==cmdInput){ accel=false; } });
 
-    // ===== Menu / Nav =====
-    const menuBtns = [...document.querySelectorAll('.menu button')];
-    const panels = [...document.querySelectorAll('#content .panel')];
-    let idx = 0;
-    function showPanel(id){ panels.forEach(p=> p.style.display = (p.id===id)?'block':'none'); menuBtns.forEach(b=> b.classList.toggle('active', b.dataset.target===id)); Beeper.beep(760, .03); }
-    menuBtns.forEach((b,i)=> b.addEventListener('click', ()=>{ idx=i; showPanel(b.dataset.target); }));
-    document.querySelectorAll('button').forEach(btn=> btn.addEventListener('mouseenter', ()=>Beeper.beep(520,.02)));
-    addEventListener('keydown', (e)=>{
-      if(ui.style.display!=='grid' || document.activeElement===cmdInput) return;
-      if(e.key==='ArrowDown'){ idx = Math.min(menuBtns.length-1, idx+1); menuBtns[idx].focus(); Beeper.beep(520,.02); }
-      else if(e.key==='ArrowUp'){ idx = Math.max(0, idx-1); menuBtns[idx].focus(); Beeper.beep(520,.02); }
-      else if(e.key==='Enter'){ menuBtns[idx].click(); }
-      else if(e.key.toLowerCase()==='m'){ menuBtns[idx].focus(); }
-    });
+      // ===== Menu / Nav =====
+      const menu = document.getElementById('mainMenu');
+      const menuBtns = [...menu.querySelectorAll('button[data-target]')];
+      const panels = [...document.querySelectorAll('#ui .panel')];
+      const backBtns = [...document.querySelectorAll('.back')];
+      let idx = 0;
+      function showMenu(){
+        menu.style.display='block';
+        panels.forEach(p=> p.style.display='none');
+        idx = 0;
+        menuBtns.forEach((b,i)=> b.classList.toggle('active', i===idx));
+        menuBtns[idx].focus();
+        Beeper.beep(760, .03);
+      }
+      function showPanel(id){
+        menu.style.display='none';
+        panels.forEach(p=> p.style.display = (p.id===id)?'block':'none');
+        Beeper.beep(760, .03);
+      }
+      menuBtns.forEach((b,i)=> b.addEventListener('click', ()=>{ idx=i; showPanel(b.dataset.target); }));
+      backBtns.forEach(btn=> btn.addEventListener('click', showMenu));
+      document.querySelectorAll('button').forEach(btn=> btn.addEventListener('mouseenter', ()=>Beeper.beep(520,.02)));
+      function highlight(){ menuBtns.forEach((b,i)=> b.classList.toggle('active', i===idx)); menuBtns[idx].focus(); Beeper.beep(520,.02); }
+      addEventListener('keydown', (e)=>{
+        if(document.activeElement===cmdInput || ui.style.display==='none') return;
+        if(menu.style.display!=='none'){
+          if(e.key==='ArrowDown'){ idx = (idx+1)%menuBtns.length; highlight(); }
+          else if(e.key==='ArrowUp'){ idx = (idx-1+menuBtns.length)%menuBtns.length; highlight(); }
+          else if(e.key==='Enter'){ menuBtns[idx].click(); }
+        } else {
+          if(e.key.toLowerCase()==='m'){ showMenu(); }
+        }
+      });
 
     const cmdMap = {
       status:'panel-status',

--- a/Vault-Tec Terminal.html
+++ b/Vault-Tec Terminal.html
@@ -85,11 +85,14 @@
     #content{overflow:auto}
 
     .menu h3{margin:0 0 8px 0; font-size:14px}
-    .menu button{display:block; width:100%; text-align:left; padding:8px 10px; margin:6px 0; font:inherit; color:inherit; background:transparent; border:1px solid currentColor; cursor:pointer}
-    .menu button:hover,.menu button.active{background:rgba(150,255,150,.08)}
+    button{font:inherit; color:inherit; background:transparent; border:none; padding:0; cursor:pointer}
+    button:hover{color:var(--accent)}
+    .menu button{display:block; width:100%; text-align:left; margin:2px 0}
+    .menu button::before{content:"> "; color:var(--accent); opacity:0}
+    .menu button:hover::before,.menu button.active::before{opacity:1}
+    .menu button:hover,.menu button.active{color:var(--accent)}
 
-    .table{width:100%; border-collapse:collapse}
-    .table th,.table td{border:1px solid currentColor; padding:6px; text-align:left}
+    .listing{white-space:pre; font-variant-ligatures:none; margin:6px 0}
     .status-ok{color:#7fffb0}.status-warn{color:#ffe27f}.status-bad{color:#ff9f9f}
 
     /* Amber mode */
@@ -185,14 +188,14 @@
           <main id="content">
             <section id="panel-status" class="panel" style="display:block">
               <h2 class="glow">VAULT STATUS</h2>
-              <table class="table">
-                <tr><th>Subsystem</th><th>State</th><th>Details</th></tr>
-                <tr><td>Power Grid</td><td class="status-ok">ONLINE</td><td>Fusion core output nominal (83%).</td></tr>
-                <tr><td>Water Purification</td><td class="status-warn">SUBOPTIMAL</td><td>Filter bed fouling at 21%. Backwash recommended.</td></tr>
-                <tr><td>Atmospheric</td><td class="status-ok">GREEN</td><td>CO2 scrubbers cycling; O2 at 20.8%.</td></tr>
-                <tr><td>Food Hydroponics</td><td class="status-warn">LOW</td><td>Nutrient A shortfall. Substitute algae slurry authorized.</td></tr>
-                <tr><td>Exterior Door</td><td class="status-bad">LOCKED</td><td>Access restricted by Directive 73-B.</td></tr>
-              </table>
+              <pre class="listing">
+Subsystem           State       Details
+Power Grid          <span class="status-ok">ONLINE</span>      Fusion core output nominal (83%).
+Water Purification  <span class="status-warn">SUBOPTIMAL</span> Filter bed fouling at 21%. Backwash recommended.
+Atmospheric         <span class="status-ok">GREEN</span>       CO2 scrubbers cycling; O2 at 20.8%.
+Food Hydroponics    <span class="status-warn">LOW</span>        Nutrient A shortfall. Substitute algae slurry authorized.
+Exterior Door       <span class="status-bad">LOCKED</span>     Access restricted by Directive 73-B.
+              </pre>
               <p class="dim">Tip: From Systems Control, reroute noncritical lighting to Purification to clear backlog faster.</p>
             </section>
 
@@ -205,14 +208,14 @@
                   <label><input type="range" id="sliderHydro" min="10" max="50" value="25" /> Hydroponics Allocation (<span id="valHydro">25</span>%)</label><br/>
                   <label><input type="range" id="sliderOther" min="0" max="80" value="30" /> Other Systems (<span id="valOther">30</span>%)</label>
                   <div class="dim">Total must remain ≤ 100%. Excess will be trimmed automatically.</div>
-                  <button id="applyPower" style="margin-top:8px">Apply Routing</button>
+                  <button id="applyPower" style="margin-top:8px">[APPLY ROUTING]</button>
                   <div id="powerMsg" class="accent" style="margin-top:6px"></div>
                 </div>
               </div>
               <div class="frame">
                 <strong>Exterior Door</strong>
                 <div style="margin-top:6px">
-                  <button id="requestOpen">Request Unlock (73-B)</button>
+                  <button id="requestOpen">[REQUEST UNLOCK 73-B]</button>
                   <div id="doorMsg" class="dim" style="margin-top:6px">Status: LOCKED by Overseer policy.</div>
                 </div>
               </div>
@@ -265,29 +268,29 @@
               <h2 class="glow">DIAGNOSTICS</h2>
               <div class="frame" style="margin-bottom:10px">
                 <strong>Device Map</strong>
-                <table class="table" style="margin-top:6px">
-                  <tr><th>Addr</th><th>Device</th><th>Status</th></tr>
-                  <tr><td>0x0010</td><td>Water Pump A</td><td class="status-ok">OK</td></tr>
-                  <tr><td>0x0011</td><td>CO2 Scrubber B</td><td class="status-ok">OK</td></tr>
-                  <tr><td>0x0200</td><td>Hydroponics Feeder</td><td class="status-warn">LOW</td></tr>
-                  <tr><td>0x0300</td><td>Door Lock Relay</td><td class="status-bad">LOCKED</td></tr>
-                </table>
+                <pre class="listing">
+Addr     Device               Status
+0x0010   Water Pump A         <span class="status-ok">OK</span>
+0x0011   CO2 Scrubber B       <span class="status-ok">OK</span>
+0x0200   Hydroponics Feeder   <span class="status-warn">LOW</span>
+0x0300   Door Lock Relay      <span class="status-bad">LOCKED</span>
+                </pre>
               </div>
               <div class="frame" style="margin-bottom:10px">
                 <strong>Memory Map</strong>
-                <table class="table" style="margin-top:6px">
-                  <tr><th>Range</th><th>Region</th><th>Notes</th></tr>
-                  <tr><td>0x0000–0x1FFF</td><td>Kernel</td><td>FO/1.2</td></tr>
-                  <tr><td>0x2000–0x3FFF</td><td>Drivers</td><td>IO, VDU, KBD</td></tr>
-                  <tr><td>0x4000–0x7FFF</td><td>User Space</td><td>Terminal UI</td></tr>
-                  <tr><td>0x8000–0x8FFF</td><td>VRAM</td><td>Monochrome buffer</td></tr>
-                </table>
+                <pre class="listing">
+Range         Region       Notes
+0x0000-0x1FFF Kernel       FO/1.2
+0x2000-0x3FFF Drivers      IO, VDU, KBD
+0x4000-0x7FFF User Space   Terminal UI
+0x8000-0x8FFF VRAM         Monochrome buffer
+                </pre>
               </div>
               <div class="frame">
                 <strong>Run POST/Diagnostics</strong>
                 <p class="dim">Simulates a vertical boot scroll you can trigger mid-session.</p>
-                <button id="btnRunPOST">Run Diagnostics Now</button>
-                <button id="btnAnomaly" style="margin-left:6px">Inject Anomaly</button>
+                <button id="btnRunPOST">[RUN DIAGNOSTICS]</button>
+                <button id="btnAnomaly" style="margin-left:6px">[INJECT ANOMALY]</button>
                 <div id="diagHint" class="dim" style="margin-top:6px">Press <b>Space</b> to accelerate, <b>Enter</b> to dismiss when finished.</div>
               </div>
             </section>

--- a/Vault-Tec Terminal.html
+++ b/Vault-Tec Terminal.html
@@ -26,7 +26,10 @@
     /* TERMINAL SHELL */
     .shell{position:relative;height:100%;display:grid;place-items:center}
     .bezel{
-      position:relative; width: 96vw; height: 92vh; /* fill most of the screen */
+      /* fixed viewport similar to Fallout terminals (approx 80x24 chars) */
+      position:relative;
+      width: calc(80ch + 2*var(--pad));
+      height: calc(24 * 1.15em + 2*var(--pad));
       border: 2px solid currentColor; padding: var(--pad); overflow:hidden;
       border-radius: 12px; box-shadow: inset 0 0 80px rgba(120,255,140,.08), 0 0 30px rgba(120,255,140,.1);
     }
@@ -57,7 +60,13 @@
     .glow{text-shadow:0 0 8px rgba(150,255,150,.45)}
 
     /* TERMINAL TEXT AREA */
-    .term{position:relative; width:100%; height:100%; overflow:hidden}
+    .term{
+      /* constrain text area to classic 80x24 characters */
+      position:relative;
+      width:80ch;
+      height:calc(24 * 1.15em);
+      overflow:hidden;
+    }
     .row{white-space:pre; font-variant-ligatures:none}
 
     /* Cursor */


### PR DESCRIPTION
## Summary
- Set terminal bezel to fixed 80×24 character viewport
- Constrain text area to match classic 80 columns by 24 rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b8cced3083298d40882776b3bbb6