### PR TITLE
Add repeating charscroll sound during typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,17 +198,20 @@ let scrollTimeout;
 let lastScrollTime=0;
 const scrollIntervalMs=750;
 
-fetch('Terminal 3/charscroll_lp.wav')
-  .then(r=>r.arrayBuffer())
-  .then(b=>audioCtx.decodeAudioData(b))
-  .then(buf=>scrollBuffer=buf);
+async function loadScrollSound(){
+  const res=await fetch('Terminal 3/charscroll_lp.wav');
+  const buf=await res.arrayBuffer();
+  scrollBuffer=await audioCtx.decodeAudioData(buf);
+}
 
 function playScrollSound(){
   if(!scrollBuffer) return;
   lastScrollTime=Date.now();
   const src=audioCtx.createBufferSource();
   src.buffer=scrollBuffer;
-  src.connect(audioCtx.destination);
+  const gain=audioCtx.createGain();
+  gain.gain.value=0.5;
+  src.connect(gain).connect(audioCtx.destination);
   src.start();
   scrollTimeout=setTimeout(playScrollSound,scrollIntervalMs);
 }
@@ -391,7 +394,7 @@ document.addEventListener('keydown',e=>{
   }
 });
 
-init();
+loadScrollSound().then(init);
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,9 @@ const audioCtx=new (window.AudioContext||window.webkitAudioContext)();
 audioCtx.resume();
 
 let scrollBuffer;
-let scrollInterval;
+let scrollTimeout;
+let lastScrollTime=0;
+const scrollIntervalMs=1500;
 
 fetch('Terminal 3/charscroll_lp.wav')
   .then(r=>r.arrayBuffer())
@@ -191,20 +193,26 @@ fetch('Terminal 3/charscroll_lp.wav')
 
 function playScrollSound(){
   if(!scrollBuffer) return;
+  lastScrollTime=Date.now();
   const src=audioCtx.createBufferSource();
   src.buffer=scrollBuffer;
   src.connect(audioCtx.destination);
   src.start();
+  scrollTimeout=setTimeout(playScrollSound,scrollIntervalMs);
 }
 function startScrollSound(){
-  if(scrollInterval) return;
-  playScrollSound();
-  scrollInterval=setInterval(playScrollSound,750);
+  if(scrollTimeout) return;
+  const elapsed=Date.now()-lastScrollTime;
+  if(elapsed>=scrollIntervalMs){
+    playScrollSound();
+  }else{
+    scrollTimeout=setTimeout(playScrollSound,scrollIntervalMs-elapsed);
+  }
 }
 function stopScrollSound(){
-  if(!scrollInterval) return;
-  clearInterval(scrollInterval);
-  scrollInterval=null;
+  if(!scrollTimeout) return;
+  clearTimeout(scrollTimeout);
+  scrollTimeout=null;
 }
 
 function playSelectSound(){
@@ -218,17 +226,6 @@ function playSelectSound(){
   src.connect(gain).connect(audioCtx.destination);
   src.start();
 }
-function playTypeSound(){
-  const buffer=audioCtx.createBuffer(1,audioCtx.sampleRate*0.01,audioCtx.sampleRate);
-  const data=buffer.getChannelData(0);
-  for(let i=0;i<data.length;i++) data[i]=(Math.random()*2-1)*Math.exp(-i/5);
-  const src=audioCtx.createBufferSource();
-  src.buffer=buffer;
-  const gain=audioCtx.createGain();
-  gain.gain.value=0.03;
-  src.connect(gain).connect(audioCtx.destination);
-  src.start();
-}
 document.addEventListener('click',()=>audioCtx.resume(),{once:true});
 document.addEventListener('keydown',()=>audioCtx.resume(),{once:true});
 
@@ -238,7 +235,6 @@ async function typeText(el,text){
   startScrollSound();
   for(let ch of text){
     el.textContent+=ch;
-    playTypeSound();
     const delay=speed===Infinity?0:baseDelay/speed;
     if(delay>0) await sleep(delay);
   }

--- a/index.html
+++ b/index.html
@@ -232,13 +232,11 @@ document.addEventListener('keydown',()=>audioCtx.resume(),{once:true});
 function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
 
 async function typeText(el,text){
-  startScrollSound();
   for(let ch of text){
     el.textContent+=ch;
     const delay=speed===Infinity?0:baseDelay/speed;
     if(delay>0) await sleep(delay);
   }
-  stopScrollSound();
   el.textContent+='\n';
 }
 
@@ -269,9 +267,11 @@ document.addEventListener('keydown',e=>{
 });
 
 async function init(){
+  startScrollSound();
   for(const line of headerLines){
     await typeText(header,line);
   }
+  stopScrollSound();
   showScreen('menu');
 }
 
@@ -284,6 +284,7 @@ async function showScreen(name){
   while(i<lines.length){
     speed=1;
     typing=true;
+    startScrollSound();
     while(i<lines.length){
       const line=lines[i];
       const div=document.createElement('div');
@@ -308,6 +309,7 @@ async function showScreen(name){
         content.removeChild(div);
         if(typeof line==='object') currentOptions.pop();
         typing=false;
+        stopScrollSound();
         await waitForContinue();
         content.innerHTML='';
         currentOptions=[];
@@ -319,6 +321,7 @@ async function showScreen(name){
     }
     if(typing){
       typing=false;
+      stopScrollSound();
       if(i<lines.length){
         await waitForContinue();
         content.innerHTML='';

--- a/index.html
+++ b/index.html
@@ -54,6 +54,10 @@
     flex:1;
     overflow:hidden;
   }
+  #input{
+    white-space:pre-wrap;
+    min-height:1.2em;
+  }
   .option{
     display:block;
     width:100%;
@@ -71,6 +75,7 @@
 <div id="terminal">
   <div id="header"></div>
   <div id="content"></div>
+  <div id="input"></div>
 </div>
 <script>
 const headerLines=[
@@ -92,8 +97,7 @@ const screens={
     {text:"> Securitron Systems Control",screen:"securitron"},
     {text:"> Experimental Robotics Files",screen:"experimental"},
     "",
-    "",
-    "> _"
+    ""
   ],
   protectron:[
     "== PROTECTRON SCHEMATICS ==",
@@ -172,11 +176,19 @@ const screens={
 
 const header=document.getElementById('header');
 const content=document.getElementById('content');
+const input=document.getElementById('input');
 let currentOptions=[];
 let selected=-1;
 let typing=false;
 let baseDelay=10;
 let speed=1;
+let inputText="";
+let screenHistory=[];
+
+function updateInput(){
+  input.innerHTML='&gt; '+inputText+'<span class="cursor">█</span>';
+}
+updateInput();
 
 const audioCtx=new (window.AudioContext||window.webkitAudioContext)();
 audioCtx.resume();
@@ -184,7 +196,7 @@ audioCtx.resume();
 let scrollBuffer;
 let scrollTimeout;
 let lastScrollTime=0;
-const scrollIntervalMs=1500;
+const scrollIntervalMs=750;
 
 fetch('Terminal 3/charscroll_lp.wav')
   .then(r=>r.arrayBuffer())
@@ -207,6 +219,14 @@ function startScrollSound(){
     playScrollSound();
   }else{
     scrollTimeout=setTimeout(playScrollSound,scrollIntervalMs-elapsed);
+  }
+}
+
+function goBack(){
+  if(screenHistory.length>1){
+    screenHistory.pop();
+    const prev=screenHistory.pop();
+    showScreen(prev);
   }
 }
 function stopScrollSound(){
@@ -276,6 +296,9 @@ async function init(){
 }
 
 async function showScreen(name){
+  screenHistory.push(name);
+  inputText='';
+  updateInput();
   content.innerHTML='';
   currentOptions=[];
   selected=-1;
@@ -330,10 +353,6 @@ async function showScreen(name){
       }
     }
   }
-  const last=content.lastChild;
-  if(last && last.textContent.trim()==='> _'){
-    last.innerHTML='&gt; <span class="cursor">█</span>';
-  }
 }
 
 document.addEventListener('keydown',e=>{
@@ -352,6 +371,23 @@ document.addEventListener('keydown',e=>{
     playSelectSound();
   }else if(e.key==='Enter' && selected>=0){
     currentOptions[selected].click();
+  }
+});
+
+document.addEventListener('keydown',e=>{
+  if(e.key==='Tab'){
+    e.preventDefault();
+    if(!typing) goBack();
+    return;
+  }
+  if(typing) return;
+  if(e.key==='Backspace'){
+    inputText=inputText.slice(0,-1);
+    updateInput();
+    e.preventDefault();
+  }else if(e.key.length===1 && !e.ctrlKey && !e.metaKey){
+    inputText+=e.key;
+    updateInput();
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -181,6 +181,32 @@ let speed=1;
 const audioCtx=new (window.AudioContext||window.webkitAudioContext)();
 audioCtx.resume();
 
+let scrollBuffer;
+let scrollInterval;
+
+fetch('Terminal 3/charscroll_lp.wav')
+  .then(r=>r.arrayBuffer())
+  .then(b=>audioCtx.decodeAudioData(b))
+  .then(buf=>scrollBuffer=buf);
+
+function playScrollSound(){
+  if(!scrollBuffer) return;
+  const src=audioCtx.createBufferSource();
+  src.buffer=scrollBuffer;
+  src.connect(audioCtx.destination);
+  src.start();
+}
+function startScrollSound(){
+  if(scrollInterval) return;
+  playScrollSound();
+  scrollInterval=setInterval(playScrollSound,750);
+}
+function stopScrollSound(){
+  if(!scrollInterval) return;
+  clearInterval(scrollInterval);
+  scrollInterval=null;
+}
+
 function playSelectSound(){
   const buffer=audioCtx.createBuffer(1,audioCtx.sampleRate*0.03,audioCtx.sampleRate);
   const data=buffer.getChannelData(0);
@@ -209,12 +235,14 @@ document.addEventListener('keydown',()=>audioCtx.resume(),{once:true});
 function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
 
 async function typeText(el,text){
+  startScrollSound();
   for(let ch of text){
     el.textContent+=ch;
     playTypeSound();
     const delay=speed===Infinity?0:baseDelay/speed;
     if(delay>0) await sleep(delay);
   }
+  stopScrollSound();
   el.textContent+='\n';
 }
 


### PR DESCRIPTION
## Summary
- load `Terminal 3/charscroll_lp.wav` and schedule playback on a 750 ms loop
- start the loop when text typing begins and stop it once typing completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afdaf69b8c8329840a65cc3feda1db